### PR TITLE
basic jest test

### DIFF
--- a/packages/unigraph-dev-explorer/package.json
+++ b/packages/unigraph-dev-explorer/package.json
@@ -64,6 +64,8 @@
     "@types/react-router-dom": "^5.1.6",
     "@types/react-virtualized": "^9.21.13",
     "@types/uuid": "^8.3.0",
+    "jest": "^27.3.1",
+    "jest-watch-typeahead": "0.6.5",
     "raw-loader": "^4.0.2"
   },
   "scripts": {

--- a/packages/unigraph-dev-explorer/src/App.test.jsx
+++ b/packages/unigraph-dev-explorer/src/App.test.jsx
@@ -1,0 +1,3 @@
+test('test suite loads', () => {
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
This PR adds the following to package.json in /unigrapg-dev-explorer:

jest@27.3.1
jest-watch-typeahead@0.6.5

It add a sample jest test in /src title App.test.tsx. This test just returns as true to prove that tests are working. The command to run: `yarn run test`