### PR TITLE
Fix code block cannot be focused

### DIFF
--- a/packages/unigraph-dev-explorer/src/examples/semantic/Markdown.tsx
+++ b/packages/unigraph-dev-explorer/src/examples/semantic/Markdown.tsx
@@ -36,8 +36,6 @@ const compFactory = (name: string, { node, inline, className, children, ...props
     React.createElement(name, {
         className,
         children,
-        contentEditable: name !== 'code', // FIXME: Look into if we can remove this line completely.
-        suppressContentEditableWarning: true,
         onPointerUp: (event: PointerEvent) => {
             const currentText = (window.getSelection() as any).anchorNode?.textContent;
             const currentNode = getTextNodes(node).filter((el: any) => el.value === currentText)[0];

--- a/packages/unigraph-dev-explorer/src/examples/semantic/Markdown.tsx
+++ b/packages/unigraph-dev-explorer/src/examples/semantic/Markdown.tsx
@@ -36,7 +36,7 @@ const compFactory = (name: string, { node, inline, className, children, ...props
     React.createElement(name, {
         className,
         children,
-        contentEditable: true,
+        contentEditable: name !== 'code', // FIXME: Look into if we can remove this line completely.
         suppressContentEditableWarning: true,
         onPointerUp: (event: PointerEvent) => {
             const currentText = (window.getSelection() as any).anchorNode?.textContent;


### PR DESCRIPTION
Disable `contenteditable` for the `<code>` element allows the code block (`<pre><code></code></pre>`, created by ```) to be focused with a single click.

I wonder if we can disable `contenteditable` for all elements, since we don't need them to be editable in the viewing mode. But also I'd love to know, does it exist for some reasons?