### PR TITLE
Make ol/ul look consistent with paragraph

### DIFF
--- a/packages/unigraph-dev-explorer/src/examples/semantic/Markdown.tsx
+++ b/packages/unigraph-dev-explorer/src/examples/semantic/Markdown.tsx
@@ -5,6 +5,7 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import remarkBreaks from 'remark-breaks';
 import 'katex/dist/katex.min.css';
+import './react-markdown.css';
 import TurndownService from 'turndown';
 import rehypeRaw from 'rehype-raw';
 import { DynamicViewRenderer } from '../../global.d';
@@ -142,6 +143,7 @@ export const Markdown: DynamicViewRenderer = ({ data, callbacks, isHeading }) =>
                 }}
             >
                 <ReactMarkdown
+                    className="react-markdown"
                     // eslint-disable-next-line react/no-children-prop
                     children={data['_value.%'] || (isHeading ? '_no title_' : '|')}
                     remarkPlugins={[remarkMath as any, remarkWikilink, remarkBreaks as any]}

--- a/packages/unigraph-dev-explorer/src/examples/semantic/react-markdown.css
+++ b/packages/unigraph-dev-explorer/src/examples/semantic/react-markdown.css
@@ -1,0 +1,4 @@
+.react-markdown ol, .react-markdown ul {
+  margin: 0;
+  padding-left: 1.15rem;
+}


### PR DESCRIPTION
The margin/padding of ol/ul was too big that they look inconsistent with other bullet points

![image](https://user-images.githubusercontent.com/25148955/161922908-dfc71962-610b-4b0f-91df-1fbd3b7aefcc.png)

This PR changes that to

![image](https://user-images.githubusercontent.com/25148955/161923372-6423209a-afa8-4cd2-b0c6-03199547e94e.png)
