### PR TITLE
docs: Build dgraph open-source version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To update the Docker image, run `docker build` again after `git pull`.
 ```bash
 git clone https://github.com/unigraph-dev/dgraph.git
 cd ./dgraph
-make install  # installs built binary in $GOPATH/bin
+make oss_install  # installs built binary in $GOPATH/bin
 ```
 
 ```bash


### PR DESCRIPTION
Per default dgraph builds the Enterprise edition of dgraph which requires jemalloc for memory allocation.
The build file has some hardcoded values for detecting jemalloc which only cover a narrow selection of Linux editions out there.
E.g. it fails on NixOS which does not follow FHS.

dgraph enterprise features are listed at https://dgraph.io/docs/enterprise-features/
and according to @thesophiaxu unigraph is not using them https://discord.com/channels/835194192044621885/914231178041634896/922968743464808468