### PR TITLE
Fix note editor behaviors

### DIFF
--- a/packages/unigraph-dev-explorer/src/examples/notes/Outline.tsx
+++ b/packages/unigraph-dev-explorer/src/examples/notes/Outline.tsx
@@ -476,7 +476,7 @@ export function Outline({
                             cx="12"
                             cy="12"
                             r="10"
-                            style={{ fill: isCollapsed ? colors.grey[200] : 'transparent' }}
+                            style={{ fill: showCollapse && isCollapsed ? colors.grey[200] : 'transparent' }}
                         />
                         <circle cx="12" cy="12" r="4" style={{ fill: 'black' }} />
                     </svg>

--- a/packages/unigraph-dev-explorer/src/examples/notes/useOutlineCollapsed.ts
+++ b/packages/unigraph-dev-explorer/src/examples/notes/useOutlineCollapsed.ts
@@ -45,3 +45,7 @@ export function useOutlineCollapsed(noteBlockUid: string): [boolean, () => void]
     );
     return [isCollapsed, toggleCollapsed];
 }
+
+export function isNoteBlockCollapsed(noteBlockUid: string): boolean {
+    return useOutlineCollapsedMap.getState().collapsedMap[noteBlockUid];
+}


### PR DESCRIPTION
* When pressing `Enter` in a collapsed note block, it should create a new note block below without moving its children to the newly created block.
* Don't show the collapsed state on a bullet (the outer ring with a lighter color around the bullet) if the note block no longer has children.